### PR TITLE
chore: switch dependency updates from Renovate to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # VitePress docs site
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+    groups:
+      docs-npm:
+        patterns: ["*"]
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Dart packages (pub workspace members)
+  - package-ecosystem: pub
+    directories:
+      - /packages/*
+      - /examples/*
+      - /tools/release
+    schedule:
+      interval: weekly
+    groups:
+      dart-deps:
+        patterns: ["*"]
+    ignore:
+      # analyzer 14 changes the AST API and needs a code migration in
+      # aim_cli (db:generate) and aim_orm_codegen; do it in a dedicated PR.
+      - dependency-name: analyzer
+        update-types: ["version-update:semver-major"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "enabled": false
 }


### PR DESCRIPTION
## Summary

Move dependency updates from Renovate to Dependabot.

- `renovate.json` now sets `"enabled": false`. To stop Renovate completely, also uninstall the Renovate GitHub App for this repo (Settings → Integrations).
- New `.github/dependabot.yml`: weekly grouped updates for `/docs` (npm), GitHub Actions, and the Dart workspace members (`/packages/*`, `/examples/*`, `/tools/release`).
- `analyzer` major updates are ignored: analyzer 14 changes the AST API and needs a code migration in `aim_cli` (`db:generate`) and `aim_orm_codegen`; that will be a dedicated PR.
- The superseded Renovate/Dependabot PRs (#62, #69, #71, #74, #75, #76, #77, #80) have been closed; #82 already applied the pending bumps.

Note: Dependabot's `pub` support with `resolution: workspace` members is untested here. If it fails to open Dart PRs, the fallback is to point it at `/` only or drop the `pub` block; security alerts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
