### PR TITLE
chore(deps)!: migrate aim_cli and aim_orm_codegen to analyzer 14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,3 @@ updates:
     groups:
       dart-deps:
         patterns: ["*"]
-    ignore:
-      # analyzer 14 changes the AST API and needs a code migration in
-      # aim_cli (db:generate) and aim_orm_codegen; do it in a dedicated PR.
-      - dependency-name: analyzer
-        update-types: ["version-update:semver-major"]

--- a/packages/aim_cli/CHANGELOG.md
+++ b/packages/aim_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Requires analyzer ^14.0.0.
 - `release:bump` now also updates the `aim_*` dependency pins inside the `aim create` templates.
 - `aim.target` (`server` | `edge`) in pubspec.yaml. With `edge`, `aim build` runs `dart compile wasm` into `build/edge/` and `aim dev` runs `npx wrangler@4 dev` with wasm recompilation on change.
 - `aim create --target edge` scaffolds a Cloudflare workerd project (`lib/main.dart`, `src/index.mjs`, `wrangler.jsonc`).

--- a/packages/aim_cli/lib/src/commands/db_generate_command.dart
+++ b/packages/aim_cli/lib/src/commands/db_generate_command.dart
@@ -180,10 +180,10 @@ class DbGenerateCommand extends Command<void> {
               final foreignKeys = <ForeignKeySchema>[];
 
               for (final field in initializer.fields) {
-                if (field is! NamedExpression) continue;
+                if (field is! RecordLiteralNamedField) continue;
 
-                final fieldName = field.name.label.name;
-                final columnInfo = _analyzeColumn(fieldName, field.expression);
+                final fieldName = field.name.lexeme;
+                final columnInfo = _analyzeColumn(fieldName, field.fieldExpression);
 
                 columns.add(columnInfo.column);
                 if (columnInfo.isIndexed) {
@@ -249,9 +249,9 @@ class DbGenerateCommand extends Command<void> {
           // varchar の length
           if (methodName == 'varchar') {
             for (final arg in args) {
-              if (arg is NamedExpression && arg.name.label.name == 'length') {
-                if (arg.expression is IntegerLiteral) {
-                  varcharLength = (arg.expression as IntegerLiteral).value;
+              if (arg is NamedArgument && arg.name.lexeme == 'length') {
+                if (arg.argumentExpression is IntegerLiteral) {
+                  varcharLength = (arg.argumentExpression as IntegerLiteral).value;
                 }
               }
             }
@@ -268,7 +268,7 @@ class DbGenerateCommand extends Command<void> {
           // withDefault(DateTime.now()) or withDefault('value') etc.
           final args = method.argumentList.arguments;
           if (args.isNotEmpty) {
-            defaultValue = _extractDefaultValue(args.first);
+            defaultValue = _extractDefaultValue(args.first.argumentExpression);
           }
         case 'references':
           // references(() => users.id, onDelete: OnDeleteAction.cascade)
@@ -348,11 +348,11 @@ class DbGenerateCommand extends Command<void> {
     return '__HAS_DEFAULT__';
   }
 
-  String? _extractOnDelete(NodeList<Expression> args) {
+  String? _extractOnDelete(NodeList<Argument> args) {
     for (final arg in args) {
-      if (arg is NamedExpression && arg.name.label.name == 'onDelete') {
-        if (arg.expression is PrefixedIdentifier) {
-          return (arg.expression as PrefixedIdentifier).identifier.name;
+      if (arg is NamedArgument && arg.name.lexeme == 'onDelete') {
+        if (arg.argumentExpression is PrefixedIdentifier) {
+          return (arg.argumentExpression as PrefixedIdentifier).identifier.name;
         }
       }
     }

--- a/packages/aim_cli/pubspec.yaml
+++ b/packages/aim_cli/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   aim_postgres: ^0.1.1
-  analyzer: ^10.0.1
+  analyzer: ^14.0.0
   args: ^2.5.0
   crypto: ^3.0.3
   path: ^1.9.0

--- a/packages/aim_orm_codegen/CHANGELOG.md
+++ b/packages/aim_orm_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Requires analyzer ^14.0.0, source_gen ^4.3.0, build ^4.0.11; compatible with build_runner 2.16.
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_orm_codegen/lib/src/record_table_generator.dart
+++ b/packages/aim_orm_codegen/lib/src/record_table_generator.dart
@@ -60,9 +60,9 @@ class RecordPgTableGenerator extends GeneratorForAnnotation<PgTable> {
     final fields = <({String name, Expression expression})>[];
     if (recordLiteral != null) {
       for (final field in recordLiteral.fields) {
-        if (field is NamedExpression) {
-          final fieldName = field.name.label.name;
-          final expression = field.expression;
+        if (field is RecordLiteralNamedField) {
+          final fieldName = field.name.lexeme;
+          final expression = field.fieldExpression;
           fields.add((name: fieldName, expression: expression));
         }
       }
@@ -1070,9 +1070,9 @@ class RecordPgTableGenerator extends GeneratorForAnnotation<PgTable> {
         // varcharの場合、名前付きパラメータ 'length' を取得
         if (methodName == 'varchar') {
           for (final arg in method.argumentList.arguments) {
-            if (arg is NamedExpression && arg.name.label.name == 'length') {
-              if (arg.expression is IntegerLiteral) {
-                varcharLength = (arg.expression as IntegerLiteral).value;
+            if (arg is NamedArgument && arg.name.lexeme == 'length') {
+              if (arg.argumentExpression is IntegerLiteral) {
+                varcharLength = (arg.argumentExpression as IntegerLiteral).value;
               }
             }
           }

--- a/packages/aim_orm_codegen/lib/src/table_collector_builder.dart
+++ b/packages/aim_orm_codegen/lib/src/table_collector_builder.dart
@@ -39,9 +39,9 @@ class TableCollectorBuilder implements Builder {
 
       final fields = <Map<String, dynamic>>[];
       for (final field in tableData.record.fields) {
-        if (field is NamedExpression) {
-          final fieldName = field.name.label.name;
-          final fieldInfo = _analyzeField(fieldName, field.expression);
+        if (field is RecordLiteralNamedField) {
+          final fieldName = field.name.lexeme;
+          final fieldInfo = _analyzeField(fieldName, field.fieldExpression);
           fields.add(fieldInfo);
         }
       }
@@ -96,9 +96,9 @@ class TableCollectorBuilder implements Builder {
 
         if (methodName == 'varchar') {
           for (final arg in method.argumentList.arguments) {
-            if (arg is NamedExpression && arg.name.label.name == 'length') {
-              if (arg.expression is IntegerLiteral) {
-                varcharLength = (arg.expression as IntegerLiteral).value;
+            if (arg is NamedArgument && arg.name.lexeme == 'length') {
+              if (arg.argumentExpression is IntegerLiteral) {
+                varcharLength = (arg.argumentExpression as IntegerLiteral).value;
               }
             }
           }

--- a/packages/aim_orm_codegen/pubspec.yaml
+++ b/packages/aim_orm_codegen/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   aim_database: ^0.1.1
   aim_orm: ^0.1.1
   aim_orm_postgres: ^0.1.1
-  analyzer: ^10.0.1
-  build: ^4.0.4
+  analyzer: ^14.0.0
+  build: ^4.0.11
   glob: ^2.1.3
-  source_gen: ^4.2.0
+  source_gen: ^4.3.0
 
 dev_dependencies:
   aim_postgres: ^0.1.1
-  build_runner: ^2.4.15
+  build_runner: ^2.16.0
   lints: ^6.0.0
   test: ^1.25.6
   path: ^1.9.0


### PR DESCRIPTION
## Summary

Migrate `aim_cli` and `aim_orm_codegen` to `analyzer ^14.0.0`, with `source_gen ^4.3.0`, `build ^4.0.11` and `build_runner ^2.16.0` for the code generator. This unblocks users on the current `build_runner`, which requires analyzer 14 and previously conflicted with our `^10` pin.

## What changed

analyzer 14 removed `NamedExpression`. Named arguments are now `NamedArgument` (`Token name`, `Expression argumentExpression`) and named record fields are `RecordLiteralNamedField` (`Token name`, `Expression fieldExpression`); `ArgumentList.arguments` is `NodeList<Argument>` and `RecordLiteral.fields` is `NodeList<RecordLiteralField>`. The three AST walkers were updated mechanically:

- `packages/aim_cli/lib/src/commands/db_generate_command.dart`
- `packages/aim_orm_codegen/lib/src/record_table_generator.dart`
- `packages/aim_orm_codegen/lib/src/table_collector_builder.dart`

No behaviour change: the golden fixtures' generated `input.g.dart` and `examples/orm-sample/lib/*.g.dart` are byte-identical after regeneration with the new toolchain.

## Verification

- `dart analyze --fatal-warnings` → 0 warnings
- `aim_cli` 12/12; `aim_orm_codegen` golden 5/5 (regenerated with build_runner 2.16 / analyzer 14, no diff)
- `examples/orm-sample`: `dart run build_runner build` → generated files unchanged

## Notes

- Resolved versions: analyzer 14.3.0, source_gen 4.3.0, build 4.0.11, build_runner 2.16.1.
- Dependabot ignores analyzer majors (`.github/dependabot.yml`); that ignore can be removed now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
