### PR TITLE
feat(edge): typed Bindings for c.env and CfProperties for c.cf

### DIFF
--- a/docs/server/middleware/index.md
+++ b/docs/server/middleware/index.md
@@ -11,6 +11,10 @@ head:
 
 Aim provides a rich ecosystem of official middleware packages for common web application needs. Each package is published separately, allowing you to include only what you need.
 
+::: tip Runs on Cloudflare workerd too
+The `aim_server_*` middleware packages (cors, cookie, form, logger, sse, jwt, basic_auth) depend on `aim_core` and work unchanged on workerd via `aim_edge`. `aim_server_static` and `aim_server_multipart`'s `saveTo()` need the file system and are VM-only.
+:::
+
 ## Available Middleware
 
 ### Core Features

--- a/examples/edge-sample/lib/main.dart
+++ b/examples/edge-sample/lib/main.dart
@@ -1,6 +1,4 @@
 import 'dart:convert';
-import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 
 import 'package:aim_edge/aim_edge.dart';
 import 'package:aim_server_cors/aim_server_cors.dart';
@@ -41,9 +39,7 @@ void main() {
   });
 
   app.get('/env', (c) async {
-    final greeting =
-        (c.env?.getProperty('GREETING'.toJS) as JSString?)?.toDart;
-    return c.text(greeting ?? 'GREETING is not set');
+    return c.text(c.env?.string('GREETING') ?? 'GREETING is not set');
   });
 
   app.get('/boom', (c) async => throw StateError('boom'));
@@ -51,6 +47,17 @@ void main() {
   app.get('/not-modified', (c) async {
     c.header('etag', '"v1"');
     return c.text('', statusCode: 304);
+  });
+
+  app.get('/cf', (c) async {
+    final cf = c.cf;
+    return c.json({
+      'country': cf?.country,
+      'colo': cf?.colo,
+      'city': cf?.city,
+      'asn': cf?.asn,
+      'latitude': cf?.latitude,
+    });
   });
 
   app.notFound((c) async => c.json({'error': 'not found'}, statusCode: 404));

--- a/packages/aim_edge/CHANGELOG.md
+++ b/packages/aim_edge/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **Breaking:** `c.req.workerEnv` / `c.req.workerContext` are replaced by `c.env` / `c.executionContext` (extension on `Context`).
 - **Breaking:** follows `aim_core`'s rename of `Env` → `Variables` and `envFactory` → `variablesFactory` (re-exported).
+- `c.env` now returns `Bindings?` (`string(name)`, `get(name)`, `has(name)`, `raw`) instead of a bare `JSObject?`.
+- New `c.cf` returns `CfProperties?` with typed getters for Cloudflare's request metadata (country, colo, city, asn, ...).
 
 ## 0.1.1
 

--- a/packages/aim_edge/README.md
+++ b/packages/aim_edge/README.md
@@ -14,7 +14,17 @@ void main() {
 
 `serveEdge()` registers `globalThis.__aimFetch`. A small JS entry module instantiates the wasm module on the first request and forwards `fetch(request, env, ctx)` to it. See `examples/edge-sample` in the repository for the build script, `wrangler.jsonc`, and the entry module.
 
-Worker bindings and the execution context are available as raw `JSObject`s via `c.env` and `c.executionContext`; type them with `dart:js_interop` in your application.
+## Bindings and request metadata
+
+`c.env` returns a typed `Bindings?`: `c.env?.string('GREETING')` reads a var or secret, `c.env?.get('MY_KV')` returns a resource binding (KV namespace, D1 database, ...) as a raw `JSObject` you call with `dart:js_interop`, and `c.env?.has('MY_KV')` checks presence.
+
+`c.cf` returns a typed `CfProperties?` for Cloudflare's `request.cf` metadata: `c.cf?.country`, `c.cf?.colo`, `c.cf?.city`, `c.cf?.asn`, and more.
+
+`c.executionContext` is still a raw `JSObject?`, for `waitUntil` / `passThroughOnException` via `dart:js_interop`.
+
+## Middleware
+
+The `aim_server_*` middleware packages (cors, cookie, form, logger, sse, jwt, basic_auth) depend on `aim_core` and work unchanged on workerd. `aim_server_static` and `aim_server_multipart`'s `saveTo()` need the file system and are VM-only.
 
 ## Limitations (v1)
 

--- a/packages/aim_edge/lib/aim_edge.dart
+++ b/packages/aim_edge/lib/aim_edge.dart
@@ -5,5 +5,7 @@
 library;
 
 export 'package:aim_core/aim_core.dart';
+export 'src/bindings.dart' show Bindings;
+export 'src/cf_properties.dart' show CfProperties;
 export 'src/edge_context.dart' show EdgeContext;
 export 'src/serve_edge.dart' show AimEdge;

--- a/packages/aim_edge/lib/src/bindings.dart
+++ b/packages/aim_edge/lib/src/bindings.dart
@@ -1,0 +1,27 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+/// The worker's bindings object (`env`): vars, secrets and resource bindings
+/// (KV, D1, R2, Durable Objects, service bindings). Hono calls this Bindings.
+class Bindings {
+  /// The underlying JS object, for bindings this class does not type.
+  final JSObject raw;
+
+  Bindings(this.raw);
+
+  /// A string var or secret, or `null` when absent or not a string.
+  String? string(String name) {
+    final value = raw.getProperty(name.toJS);
+    return value.isA<JSString>() ? (value as JSString).toDart : null;
+  }
+
+  /// A resource binding (KV namespace, D1 database, ...), or `null` when
+  /// absent or not an object. Use `dart:js_interop` to call it.
+  JSObject? get(String name) {
+    final value = raw.getProperty(name.toJS);
+    return value.isA<JSObject>() ? value as JSObject : null;
+  }
+
+  /// Whether [name] exists on the bindings object.
+  bool has(String name) => raw.has(name);
+}

--- a/packages/aim_edge/lib/src/cf_properties.dart
+++ b/packages/aim_edge/lib/src/cf_properties.dart
@@ -1,0 +1,48 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+/// Cloudflare's `request.cf` metadata (`IncomingRequestCfProperties`).
+class CfProperties {
+  final JSObject raw;
+
+  CfProperties(this.raw);
+
+  String? get country => _string('country');
+  String? get colo => _string('colo');
+  String? get city => _string('city');
+  String? get region => _string('region');
+  String? get regionCode => _string('regionCode');
+  String? get continent => _string('continent');
+  String? get timezone => _string('timezone');
+  String? get postalCode => _string('postalCode');
+  double? get latitude => _double('latitude');
+  double? get longitude => _double('longitude');
+  int? get asn => _int('asn');
+  String? get asOrganization => _string('asOrganization');
+  String? get httpProtocol => _string('httpProtocol');
+  String? get tlsVersion => _string('tlsVersion');
+  String? get tlsCipher => _string('tlsCipher');
+
+  /// Any other property as a string (e.g. `botManagement` sub-fields are not
+  /// covered), or `null` when absent or not a string.
+  String? string(String name) => _string(name);
+
+  String? _string(String name) {
+    final value = raw.getProperty(name.toJS);
+    return value.isA<JSString>() ? (value as JSString).toDart : null;
+  }
+
+  double? _double(String name) {
+    final value = raw.getProperty(name.toJS);
+    if (value.isA<JSNumber>()) return (value as JSNumber).toDartDouble;
+    if (value.isA<JSString>()) return double.tryParse((value as JSString).toDart);
+    return null;
+  }
+
+  int? _int(String name) {
+    final value = raw.getProperty(name.toJS);
+    if (value.isA<JSNumber>()) return (value as JSNumber).toDartInt;
+    if (value.isA<JSString>()) return int.tryParse((value as JSString).toDart);
+    return null;
+  }
+}

--- a/packages/aim_edge/lib/src/cf_properties.dart
+++ b/packages/aim_edge/lib/src/cf_properties.dart
@@ -35,7 +35,8 @@ class CfProperties {
   double? _double(String name) {
     final value = raw.getProperty(name.toJS);
     if (value.isA<JSNumber>()) return (value as JSNumber).toDartDouble;
-    if (value.isA<JSString>()) return double.tryParse((value as JSString).toDart);
+    if (value.isA<JSString>())
+      return double.tryParse((value as JSString).toDart);
     return null;
   }
 

--- a/packages/aim_edge/lib/src/edge_context.dart
+++ b/packages/aim_edge/lib/src/edge_context.dart
@@ -1,6 +1,9 @@
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:aim_core/aim_core.dart';
+import 'package:aim_edge/src/bindings.dart';
+import 'package:aim_edge/src/cf_properties.dart';
 import 'package:aim_edge/src/edge_request.dart';
 
 /// Access to the Cloudflare workerd runtime from a request handled by `aim_edge`.
@@ -9,11 +12,11 @@ extension EdgeContext<E extends Variables> on Context<E> {
   /// Durable Object namespaces and service bindings.
   ///
   /// `null` when the request was not produced by the workerd adapter.
-  /// Type it in your application with `dart:js_interop`, for example
-  /// `(c.env?.getProperty('GREETING'.toJS) as JSString?)?.toDart`.
-  JSObject? get env {
+  /// Read a var or secret with `c.env?.string('GREETING')`, or a resource
+  /// binding with `c.env?.get('MY_KV')`.
+  Bindings? get env {
     final r = request.raw;
-    return r is EdgeRawRequest ? r.env : null;
+    return r is EdgeRawRequest ? Bindings(r.env) : null;
   }
 
   /// The worker's `ExecutionContext` (`ctx`), used for `waitUntil` and
@@ -21,5 +24,16 @@ extension EdgeContext<E extends Variables> on Context<E> {
   JSObject? get executionContext {
     final r = request.raw;
     return r is EdgeRawRequest ? r.ctx : null;
+  }
+
+  /// Cloudflare's `request.cf` metadata (colo, country, coordinates, ...).
+  ///
+  /// `null` when the request was not produced by the workerd adapter, or
+  /// when the runtime did not populate `cf` (e.g. some local dev setups).
+  CfProperties? get cf {
+    final r = request.raw;
+    if (r is! EdgeRawRequest) return null;
+    final value = r.request.getProperty('cf'.toJS);
+    return value.isA<JSObject>() ? CfProperties(value as JSObject) : null;
   }
 }

--- a/packages/aim_edge/test/integration/wrangler_dev_test.dart
+++ b/packages/aim_edge/test/integration/wrangler_dev_test.dart
@@ -213,6 +213,16 @@ void main() {
     expect(await utf8.decodeStream(res), 'hello from workerd');
   });
 
+  test('exposes request.cf as typed properties', () async {
+    final res = await get('/cf');
+    expect(res.statusCode, 200);
+    final body = jsonDecode(await utf8.decodeStream(res)) as Map;
+    expect(body['country'], isA<String>().having((s) => s.length, 'length', 2));
+    expect(body['colo'], isA<String>().having((s) => s.isNotEmpty, 'non-empty', isTrue));
+    expect(body['asn'], anyOf(isNull, isA<int>()));
+    expect(body['latitude'], anyOf(isNull, isA<num>()));
+  });
+
   test('uses the custom 404 handler', () async {
     final res = await get('/nope');
     expect(res.statusCode, 404);

--- a/packages/aim_edge/test/public_api_test.dart
+++ b/packages/aim_edge/test/public_api_test.dart
@@ -8,11 +8,14 @@ import 'package:test/test.dart';
 void main() {
   test('lib/aim_edge.dart exports only the allowed surface', () {
     final source = File('lib/aim_edge.dart').readAsStringSync();
-    final exports = RegExp(r'''^export\s+['"]([^'"]+)['"](\s+show\s+([^;]+))?;''',
-            multiLine: true)
-        .allMatches(source)
-        .map((m) => (uri: m.group(1)!, show: m.group(3)?.trim()))
-        .toList();
+    final exports =
+        RegExp(
+              r'''^export\s+['"]([^'"]+)['"](\s+show\s+([^;]+))?;''',
+              multiLine: true,
+            )
+            .allMatches(source)
+            .map((m) => (uri: m.group(1)!, show: m.group(3)?.trim()))
+            .toList();
 
     expect(exports, hasLength(5));
     expect(exports[0], (uri: 'package:aim_core/aim_core.dart', show: null));
@@ -27,8 +30,9 @@ void main() {
     final context = File('lib/src/edge_context.dart').readAsStringSync();
     final serve = File('lib/src/serve_edge.dart').readAsStringSync();
     final publicMembers = RegExp(
-        r'^\s{2}(?:JSObject\?|Bindings\?|CfProperties\?|void)\s+(?:get\s+)?\w+',
-        multiLine: true);
+      r'^\s{2}(?:JSObject\?|Bindings\?|CfProperties\?|void)\s+(?:get\s+)?\w+',
+      multiLine: true,
+    );
     // Any two-space-indented line that looks like the start of a member
     // declaration (starts with a letter, so doc comments starting with
     // `//`/`///` are excluded automatically since they start with `/`).
@@ -45,11 +49,17 @@ void main() {
       // full method body: AimEdge.serveEdge()'s implementation references
       // web.Request inside an internal closure, which is fine as long as
       // that type never appears in the member's public signature.
-      final signatures =
-          publicMembers.allMatches(body).map((m) => m.group(0)!).join('\n');
-      expect(signatures, isNot(contains('web.')),
-          reason: 'exported extension member signature mentions a '
-              'package:web type:\n$signatures');
+      final signatures = publicMembers
+          .allMatches(body)
+          .map((m) => m.group(0)!)
+          .join('\n');
+      expect(
+        signatures,
+        isNot(contains('web.')),
+        reason:
+            'exported extension member signature mentions a '
+            'package:web type:\n$signatures',
+      );
       expect(publicMembers.hasMatch(body), isTrue);
       // Every top-level declaration line in the extension body must be one
       // of the JSObject?/Bindings?/CfProperties?/void-returning members
@@ -58,7 +68,8 @@ void main() {
       expect(
         declarationLines.allMatches(body).length,
         equals(publicMembers.allMatches(body).length),
-        reason: 'every exported member must return JSObject?, Bindings?, '
+        reason:
+            'every exported member must return JSObject?, Bindings?, '
             'CfProperties? or void',
       );
     }
@@ -75,35 +86,85 @@ void main() {
       'JSObject?',
       'JSObject',
     };
-    final publicMemberLine = RegExp(
-      r'^  (?:final\s+)?(String\?|double\?|int\?|bool|JSObject\?|JSObject)\s+'
-      r'(?:get\s+)?\w+',
+    // Matches the head of any public member declaration line: an optional
+    // `final`, a return-type token, an optional `get`, then an identifier
+    // that does NOT start with `_` (excludes the private `_string`/`_double`/
+    // `_int` helpers). Deliberately permissive about the return type itself
+    // -- it matches a member whose return type is one of the allowed ones
+    // just as readily as e.g. a hypothetical `Object? get bogus`. A
+    // constructor line (`Bindings(this.raw);`) never matches: there is no
+    // whitespace between the class name and `(`, so the required `[ \t]+`
+    // after the leading token can't be satisfied. A doc-comment line is
+    // excluded by the `(?!/)` lookahead right after the indent. The gaps
+    // use `[ \t]+` rather than `\s+` so a match can never cross a newline:
+    // `\s+` would let a private helper's closing `}` chain across the
+    // blank line into the next member's return-type token, fabricating a
+    // phantom match.
+    final publicDeclarationHead = RegExp(
+      r'^  (?!/)(?:final[ \t]+)?\S+[ \t]+(?:get[ \t]+)?[A-Za-z]\w*\b',
       multiLine: true,
     );
-    final declarationLines = RegExp(r'^  [A-Za-z_][^\n]*$', multiLine: true);
+    // Same shape, but the return-type token is restricted to the allowed
+    // set. If every public member has an allowed return type, this matches
+    // exactly as many lines as [publicDeclarationHead]; if some public
+    // member's return type is NOT in the allowed set, this regex silently
+    // fails to match that line while [publicDeclarationHead] still does,
+    // so the counts diverge below and the test fails.
+    final typedPublicDeclarationHead = RegExp(
+      r'^  (?!/)(?:final[ \t]+)?(String\?|double\?|int\?|bool|JSObject\?|JSObject)'
+      r'[ \t]+(?:get[ \t]+)?[A-Za-z]\w*\b',
+      multiLine: true,
+    );
 
-    for (final source in [bindings, cfProperties]) {
+    for (final entry in {
+      'Bindings': bindings,
+      'CfProperties': cfProperties,
+    }.entries) {
+      final className = entry.key;
+      final source = entry.value;
       expect(source, isNot(contains('package:web')));
+
+      final body = _classBody(source, className);
+
       // No public member line mentions a package:web type.
-      final memberLines = declarationLines
-          .allMatches(source)
+      final publicLines = publicDeclarationHead
+          .allMatches(body)
           .map((m) => m.group(0)!)
-          // Exclude private helpers (leading underscore after the type).
-          .where((line) => !RegExp(r'^\s{2}\S+\s+_\w').hasMatch(line))
           .toList();
-      for (final line in memberLines) {
-        expect(line, isNot(contains('web.')),
-            reason: 'public member mentions a package:web type: $line');
+      for (final line in publicLines) {
+        expect(
+          line,
+          isNot(contains('web.')),
+          reason:
+              'public member of $className mentions a package:web '
+              'type: $line',
+        );
       }
+
       // Every public member's declared return type is one of the allowed
-      // types.
-      final publicMatches = publicMemberLine.allMatches(source).toList();
-      for (final match in publicMatches) {
-        expect(allowedReturnTypes, contains(match.group(1)),
-            reason: 'unexpected public return type in: ${match.group(0)}');
-      }
+      // types: if the two counts diverge, some public member has a return
+      // type outside [allowedReturnTypes].
+      expect(
+        typedPublicDeclarationHead.allMatches(body).length,
+        equals(publicDeclarationHead.allMatches(body).length),
+        reason:
+            'every public member of $className must return one of '
+            '$allowedReturnTypes',
+      );
     }
   });
+}
+
+String _classBody(String source, String name) {
+  final start = source.indexOf(RegExp('class $name\\b'));
+  expect(start, greaterThanOrEqualTo(0), reason: 'class $name not found');
+  var depth = 0;
+  for (var i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] == '{') depth++;
+    if (source[i] == '}') depth--;
+    if (depth == 0) return source.substring(start, i + 1);
+  }
+  fail('unbalanced braces in $name');
 }
 
 String _extensionBody(String source, String name) {

--- a/packages/aim_edge/test/public_api_test.dart
+++ b/packages/aim_edge/test/public_api_test.dart
@@ -2,8 +2,9 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
-/// The public barrel may export aim_core and the two adapter extensions only,
-/// and must never make a package:web type reachable.
+/// The public barrel may export aim_core, the Bindings/CfProperties value
+/// types, and the two adapter extensions only, and must never make a
+/// package:web type reachable.
 void main() {
   test('lib/aim_edge.dart exports only the allowed surface', () {
     final source = File('lib/aim_edge.dart').readAsStringSync();
@@ -13,23 +14,27 @@ void main() {
         .map((m) => (uri: m.group(1)!, show: m.group(3)?.trim()))
         .toList();
 
-    expect(exports, hasLength(3));
+    expect(exports, hasLength(5));
     expect(exports[0], (uri: 'package:aim_core/aim_core.dart', show: null));
-    expect(exports[1], (uri: 'src/edge_context.dart', show: 'EdgeContext'));
-    expect(exports[2], (uri: 'src/serve_edge.dart', show: 'AimEdge'));
+    expect(exports[1], (uri: 'src/bindings.dart', show: 'Bindings'));
+    expect(exports[2], (uri: 'src/cf_properties.dart', show: 'CfProperties'));
+    expect(exports[3], (uri: 'src/edge_context.dart', show: 'EdgeContext'));
+    expect(exports[4], (uri: 'src/serve_edge.dart', show: 'AimEdge'));
     expect(source, isNot(contains('package:web')));
   });
 
   test('exported extensions expose no package:web types', () {
     final context = File('lib/src/edge_context.dart').readAsStringSync();
     final serve = File('lib/src/serve_edge.dart').readAsStringSync();
-    final publicMembers = RegExp(r'^\s{2}(?:JSObject\?|void)\s+(?:get\s+)?\w+',
+    final publicMembers = RegExp(
+        r'^\s{2}(?:JSObject\?|Bindings\?|CfProperties\?|void)\s+(?:get\s+)?\w+',
         multiLine: true);
     // Any two-space-indented line that looks like the start of a member
     // declaration (starts with a letter, so doc comments starting with
     // `//`/`///` are excluded automatically since they start with `/`).
     final declarationLines = RegExp(r'^  [A-Za-z_][^\n]*$', multiLine: true);
-    // Every member of the two exported extensions returns JSObject? or void.
+    // Every member of the two exported extensions returns JSObject?,
+    // Bindings?, CfProperties? or void.
     final extensionBodies = [
       _extensionBody(context, 'EdgeContext'),
       _extensionBody(serve, 'AimEdge'),
@@ -47,14 +52,56 @@ void main() {
               'package:web type:\n$signatures');
       expect(publicMembers.hasMatch(body), isTrue);
       // Every top-level declaration line in the extension body must be one
-      // of the JSObject?/void-returning members matched above: if the two
-      // counts diverge, some member has snuck in with a different return
-      // type that publicMembers failed to catch.
+      // of the JSObject?/Bindings?/CfProperties?/void-returning members
+      // matched above: if the two counts diverge, some member has snuck in
+      // with a different return type that publicMembers failed to catch.
       expect(
         declarationLines.allMatches(body).length,
         equals(publicMembers.allMatches(body).length),
-        reason: 'every exported member must return JSObject? or void',
+        reason: 'every exported member must return JSObject?, Bindings?, '
+            'CfProperties? or void',
       );
+    }
+  });
+
+  test('Bindings and CfProperties expose no package:web types', () {
+    final bindings = File('lib/src/bindings.dart').readAsStringSync();
+    final cfProperties = File('lib/src/cf_properties.dart').readAsStringSync();
+    const allowedReturnTypes = {
+      'String?',
+      'double?',
+      'int?',
+      'bool',
+      'JSObject?',
+      'JSObject',
+    };
+    final publicMemberLine = RegExp(
+      r'^  (?:final\s+)?(String\?|double\?|int\?|bool|JSObject\?|JSObject)\s+'
+      r'(?:get\s+)?\w+',
+      multiLine: true,
+    );
+    final declarationLines = RegExp(r'^  [A-Za-z_][^\n]*$', multiLine: true);
+
+    for (final source in [bindings, cfProperties]) {
+      expect(source, isNot(contains('package:web')));
+      // No public member line mentions a package:web type.
+      final memberLines = declarationLines
+          .allMatches(source)
+          .map((m) => m.group(0)!)
+          // Exclude private helpers (leading underscore after the type).
+          .where((line) => !RegExp(r'^\s{2}\S+\s+_\w').hasMatch(line))
+          .toList();
+      for (final line in memberLines) {
+        expect(line, isNot(contains('web.')),
+            reason: 'public member mentions a package:web type: $line');
+      }
+      // Every public member's declared return type is one of the allowed
+      // types.
+      final publicMatches = publicMemberLine.allMatches(source).toList();
+      for (final match in publicMatches) {
+        expect(allowedReturnTypes, contains(match.group(1)),
+            reason: 'unexpected public return type in: ${match.group(0)}');
+      }
     }
   });
 }

--- a/packages/aim_edge/test/wasm_smoke/app.dart
+++ b/packages/aim_edge/test/wasm_smoke/app.dart
@@ -5,6 +5,7 @@ import 'package:aim_edge/aim_edge.dart';
 void main() {
   final app = Aim();
   app.get('/env', (c) async => c.text('${c.env != null}'));
+  app.get('/cf', (c) async => c.text('${c.cf?.country}'));
   app.get('/', (c) async => c.text('ok'));
   app.serveEdge();
 }


### PR DESCRIPTION
## Summary

Typed access to the two workerd objects users touch most, so application code no longer needs `dart:js_interop` for the common cases. Follows the design decisions from the aim_edge review: keep `c.executionContext` as is, wrap `c.env`, expose `request.cf` typed, keep the `aim_server_*` names and document that they run on workerd.

## API

```dart
// vars / secrets and resource bindings (Hono: Bindings)
final greeting = c.env?.string('GREETING');   // String?
final kv = c.env?.get('MY_KV');                // JSObject? for js_interop
c.env?.has('API_KEY');                          // bool
c.env?.raw;                                     // JSObject

// Cloudflare request metadata (request.cf)
c.cf?.country;        // 'JP'
c.cf?.colo;           // 'NRT'
c.cf?.city; c.cf?.region; c.cf?.regionCode; c.cf?.continent; c.cf?.timezone; c.cf?.postalCode;
c.cf?.latitude;       // double? (Cloudflare sends strings; parsed)
c.cf?.asn;            // int?
c.cf?.asOrganization; c.cf?.httpProtocol; c.cf?.tlsVersion; c.cf?.tlsCipher;
c.cf?.string('someOtherKey');
```

**Breaking (unreleased):** `c.env` returns `Bindings?` instead of `JSObject?`; use `c.env?.raw` for the previous object.

No `package:web` type appears in the public API; `public_api_test.dart` now also checks the return types of every public member of `Bindings` and `CfProperties`.

## Also

- `examples/edge-sample`: `/env` uses `c.env?.string(...)`; new `/cf` route; integration test asserts real `request.cf` data from `wrangler dev` (`{"country":"JP","colo":"NRT","city":"Narita","asn":13335,"latitude":35.78333}` observed locally).
- README (`aim_edge`) and `docs/server/middleware/index.md`: the `aim_server_*` middleware packages run unchanged on workerd; `aim_server_static` and multipart's `saveTo()` are VM-only.

## Verification

- `dart analyze --fatal-warnings` → 0 warnings
- `aim_edge` 18/18 (public API guard, import scan, wasm smoke, 13 wrangler integration cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
