### PR TITLE
chore: release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.2.0
+
+Second beta. Aim now runs on Cloudflare workerd as well as the Dart VM, `aim_postgres` pools connections, and the per-request variable type follows Hono's naming. This release contains breaking changes; see the [Migration Guide](https://aim-dart.dev/server/guides/migration) for step-by-step instructions.
+
+### Highlights
+
+- **`aim_core`** (new): the framework core (`Aim`, routing, middleware, `Context`, `Request`, `Response`) with no `dart:io` dependency. `aim_server` re-exports it, so existing imports keep working.
+- **`aim_edge`** (new): run the same app on Cloudflare workerd, compiled with `dart compile wasm`. `app.serveEdge()`, `c.env` (`Bindings`), `c.cf` (`CfProperties`), `c.executionContext`. Streaming responses (SSE) work.
+- **`aim_cli`**: `aim: target: edge` in `pubspec.yaml` switches `aim build` to WebAssembly and `aim dev` to `wrangler dev` with recompilation on change. `aim create --target edge` scaffolds a worker project.
+- **`aim_postgres`**: connection pooling in `PostgresDatabase.connect()` (`maxConnections`, `acquireTimeout`, `idleTimeout`, `maxLifetime`, `validationInterval`, `poolStats`). Queries on one connection are serialized, fixing protocol corruption under concurrent requests.
+- Requires Dart 3.13.
+
+### Breaking changes
+
+- `Env` → `Variables`, `EmptyEnv` → `EmptyVariables`; `Aim(envFactory:)` → `Aim(variablesFactory:)`. `JwtEnv` → `JwtVariables`, `BasicAuthEnv` → `BasicAuthVariables`. Deprecated typedefs for the class names remain for this release; `envFactory` has no alias.
+- `Request.raw` is `Object?`. On the VM use `c.req.httpRequest` (extension from `aim_server`).
+- `aim_server_multipart`: `UploadedFile.saveTo()` moved to `package:aim_server_multipart/aim_server_multipart_io.dart`. The main library now exports the public API (`MultipartFormData`, `UploadedFile`, `parseMultipart`, `MultipartRequest`); `src/` imports should be replaced.
+- `aim_cli`: `--entry` now overrides `aim.entry` for `aim dev` too; `aim.env` values are parsed as YAML (quote values containing `:`); errors exit non-zero.
+- `aim_postgres`: `db.query()` / `db.execute()` inside a `transaction()` callback now run on a separate pooled connection. Use `tx` for statements that belong to the transaction. Session state (`SET`, `TEMP` tables, `LISTEN`, advisory locks) no longer persists across calls; pass `maxConnections: 1` to keep single-connection behaviour.
+- `aim_orm_codegen` and `aim_cli` require `analyzer ^14.0.0`; the code generator works with `source_gen ^4.3.0` and `build_runner 2.16`.
+
+### Other changes
+
+- Middleware packages (`aim_server_cors`, `cookie`, `form`, `logger`, `sse`, `jwt`, `basic_auth`, `multipart`) depend on `aim_core` and run unchanged on both runtimes. `aim_server_static` remains VM-only.
+- `aim_server`: `Aim.handle()` no longer prints unhandled errors; `serve()` still logs them.
+- `aim_postgres`: `PostgresConnection.isBroken`, `isClosed`, `ping()`; `PoolTimeoutException`.
+- `aim_cli`: `aim:` configuration is parsed with `package:yaml`; the release tooling keeps the scaffold templates' dependency pins in sync.
+- Docs: new Migration Guide, CLI `target` documentation, connection pooling guide.
+
+### Packages in this release
+
+`aim_core` 0.2.0 (new), `aim_server`, `aim_edge` 0.2.0 (new), `aim_cli`, `aim_server_cors`, `aim_server_cookie`, `aim_server_form`, `aim_server_multipart`, `aim_server_static`, `aim_server_logger`, `aim_server_sse`, `aim_server_jwt`, `aim_server_basic_auth`, `aim_server_testing`, `aim_database`, `aim_postgres`, `aim_orm`, `aim_orm_postgres`, `aim_orm_codegen` — all 0.2.0.
+
 ## Unreleased
 
 ### Database (aim_postgres)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -24,7 +24,7 @@ const jsonLdSoftware = {
     "url": "https://github.com/aim-dart"
   },
   "programmingLanguage": "Dart",
-  "softwareVersion": "0.1.1",
+  "softwareVersion": "0.2.0",
   "license": "https://opensource.org/licenses/MIT"
 }
 
@@ -112,7 +112,7 @@ export default defineConfig({
       { text: 'Database', link: '/database/', activeMatch: '/database/' },
       { text: 'CLI', link: '/cli/', activeMatch: '/cli/' },
       {
-        text: 'v0.1.1',
+        text: 'v0.2.0',
         items: [
           { text: 'Changelog', link: 'https://github.com/aim-dart/aim/releases' },
           { text: 'Contributing', link: 'https://github.com/aim-dart/aim/blob/main/CONTRIBUTING.md' }

--- a/packages/aim_cli/CHANGELOG.md
+++ b/packages/aim_cli/CHANGELOG.md
@@ -1,11 +1,11 @@
-## Unreleased
+## 0.2.0
 
 - Requires analyzer ^14.0.0.
 - `release:bump` now also updates the `aim_*` dependency pins inside the `aim create` templates.
 - `aim.target` (`server` | `edge`) in pubspec.yaml. With `edge`, `aim build` runs `dart compile wasm` into `build/edge/` and `aim dev` runs `npx wrangler@4 dev` with wasm recompilation on change.
 - `aim create --target edge` scaffolds a Cloudflare workerd project (`lib/main.dart`, `src/index.mjs`, `wrangler.jsonc`).
 - `aim:` configuration is now parsed with `package:yaml`. Entry resolution is `--entry` > `aim.entry` > default for both `dev` and `build` (previously `dev` let `aim.entry` override `--entry`).
-- Server template depends on `aim_server: ^0.1.1` (was `^0.0.6`).
+- Server template's `aim_server` pin is kept in sync with the release version by `release:bump` (was hard-coded `^0.0.6`).
 
 ## 0.1.1
 

--- a/packages/aim_cli/lib/src/templates/templates.dart
+++ b/packages/aim_cli/lib/src/templates/templates.dart
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_server: ^0.1.1
+  aim_server: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0
@@ -315,7 +315,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_edge: ^0.1.1
+  aim_edge: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/aim_cli/pubspec.yaml
+++ b/packages/aim_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_cli
 description: Command-line tools for the Aim framework with project scaffolding, development server, and hot reload support.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_postgres: ^0.1.1
+  aim_postgres: ^0.2.0
   analyzer: ^14.0.0
   args: ^2.5.0
   crypto: ^3.0.3

--- a/packages/aim_cli/test/commands/create_command_test.dart
+++ b/packages/aim_cli/test/commands/create_command_test.dart
@@ -60,7 +60,10 @@ void main() {
 
     expect(File(p.join(tmp.path, 'my_server/bin/server.dart')).existsSync(), isTrue);
     expect(File(p.join(tmp.path, 'my_server/Dockerfile')).existsSync(), isTrue);
-    expect(read('my_server/pubspec.yaml'), contains('aim_server: ^0.1.1'));
+    expect(
+      read('my_server/pubspec.yaml'),
+      matches(RegExp(r'aim_server: \^\d+\.\d+\.\d+')),
+    );
     expect(read('my_server/pubspec.yaml'), isNot(contains('target: edge')));
   });
 

--- a/packages/aim_core/CHANGELOG.md
+++ b/packages/aim_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 - **Breaking:** `Env` is renamed to `Variables` and `EmptyEnv` to `EmptyVariables`, matching Hono's terminology. Deprecated typedefs `Env` and `EmptyEnv` remain for one release.
 - **Breaking:** the `Aim` constructor parameter `envFactory` is renamed to `variablesFactory`.

--- a/packages/aim_core/pubspec.yaml
+++ b/packages/aim_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_core
 description: Platform-independent core of the Aim web framework. Routing, middleware, request and response types with no dart:io dependency.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 

--- a/packages/aim_database/CHANGELOG.md
+++ b/packages/aim_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_database/pubspec.yaml
+++ b/packages/aim_database/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_database
 description: Database abstraction layer for Aim. Provides common interfaces for database drivers like aim_postgres.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 

--- a/packages/aim_edge/CHANGELOG.md
+++ b/packages/aim_edge/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 - **Breaking:** `c.req.workerEnv` / `c.req.workerContext` are replaced by `c.env` / `c.executionContext` (extension on `Context`).
 - **Breaking:** follows `aim_core`'s rename of `Env` → `Variables` and `envFactory` → `variablesFactory` (re-exported).

--- a/packages/aim_edge/pubspec.yaml
+++ b/packages/aim_edge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_edge
 description: Run Aim web applications on Cloudflare workerd (Cloudflare Workers) compiled to WebAssembly with dart compile wasm.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
   web: ^1.1.1
 
 dev_dependencies:

--- a/packages/aim_orm/CHANGELOG.md
+++ b/packages/aim_orm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_orm/pubspec.yaml
+++ b/packages/aim_orm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_orm
 description: A type-safe ORM abstraction layer for Dart with query builders and column definitions.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_database: ^0.1.1
+  aim_database: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/aim_orm_codegen/CHANGELOG.md
+++ b/packages/aim_orm_codegen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 - Requires analyzer ^14.0.0, source_gen ^4.3.0, build ^4.0.11; compatible with build_runner 2.16.
 

--- a/packages/aim_orm_codegen/pubspec.yaml
+++ b/packages/aim_orm_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_orm_codegen
 description: Code generation for aim_orm using build_runner. Generates type-safe query builders from table definitions.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,16 +8,16 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_database: ^0.1.1
-  aim_orm: ^0.1.1
-  aim_orm_postgres: ^0.1.1
+  aim_database: ^0.2.0
+  aim_orm: ^0.2.0
+  aim_orm_postgres: ^0.2.0
   analyzer: ^14.0.0
   build: ^4.0.11
   glob: ^2.1.3
   source_gen: ^4.3.0
 
 dev_dependencies:
-  aim_postgres: ^0.1.1
+  aim_postgres: ^0.2.0
   build_runner: ^2.16.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_orm_codegen/test/golden/fixtures/foreign_key/pubspec.yaml
+++ b/packages/aim_orm_codegen/test/golden/fixtures/foreign_key/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_orm: ^0.1.1
-  aim_orm_postgres: ^0.1.1
-  aim_postgres: ^0.1.1
-  aim_database: ^0.1.1
+  aim_orm: ^0.2.0
+  aim_orm_postgres: ^0.2.0
+  aim_postgres: ^0.2.0
+  aim_database: ^0.2.0
 
 dev_dependencies:
-  aim_orm_codegen: ^0.1.1
+  aim_orm_codegen: ^0.2.0
   build_runner: ^2.4.0

--- a/packages/aim_orm_codegen/test/golden/fixtures/multiple_fk/pubspec.yaml
+++ b/packages/aim_orm_codegen/test/golden/fixtures/multiple_fk/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_orm: ^0.1.1
-  aim_orm_postgres: ^0.1.1
-  aim_postgres: ^0.1.1
-  aim_database: ^0.1.1
+  aim_orm: ^0.2.0
+  aim_orm_postgres: ^0.2.0
+  aim_postgres: ^0.2.0
+  aim_database: ^0.2.0
 
 dev_dependencies:
-  aim_orm_codegen: ^0.1.1
+  aim_orm_codegen: ^0.2.0
   build_runner: ^2.4.0

--- a/packages/aim_orm_codegen/test/golden/fixtures/nullable_columns/pubspec.yaml
+++ b/packages/aim_orm_codegen/test/golden/fixtures/nullable_columns/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_orm: ^0.1.1
-  aim_orm_postgres: ^0.1.1
-  aim_postgres: ^0.1.1
-  aim_database: ^0.1.1
+  aim_orm: ^0.2.0
+  aim_orm_postgres: ^0.2.0
+  aim_postgres: ^0.2.0
+  aim_database: ^0.2.0
 
 dev_dependencies:
-  aim_orm_codegen: ^0.1.1
+  aim_orm_codegen: ^0.2.0
   build_runner: ^2.4.0

--- a/packages/aim_orm_codegen/test/golden/fixtures/nullable_fk/pubspec.yaml
+++ b/packages/aim_orm_codegen/test/golden/fixtures/nullable_fk/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_orm: ^0.1.1
-  aim_orm_postgres: ^0.1.1
-  aim_postgres: ^0.1.1
-  aim_database: ^0.1.1
+  aim_orm: ^0.2.0
+  aim_orm_postgres: ^0.2.0
+  aim_postgres: ^0.2.0
+  aim_database: ^0.2.0
 
 dev_dependencies:
-  aim_orm_codegen: ^0.1.1
+  aim_orm_codegen: ^0.2.0
   build_runner: ^2.4.0

--- a/packages/aim_orm_codegen/test/golden/fixtures/simple_table/pubspec.yaml
+++ b/packages/aim_orm_codegen/test/golden/fixtures/simple_table/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_orm: ^0.1.1
-  aim_orm_postgres: ^0.1.1
-  aim_postgres: ^0.1.1
-  aim_database: ^0.1.1
+  aim_orm: ^0.2.0
+  aim_orm_postgres: ^0.2.0
+  aim_postgres: ^0.2.0
+  aim_database: ^0.2.0
 
 dev_dependencies:
-  aim_orm_codegen: ^0.1.1
+  aim_orm_codegen: ^0.2.0
   build_runner: ^2.4.0

--- a/packages/aim_orm_postgres/CHANGELOG.md
+++ b/packages/aim_orm_postgres/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_orm_postgres/pubspec.yaml
+++ b/packages/aim_orm_postgres/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_orm_postgres
 description: PostgreSQL ORM implementation for Dart with Record syntax table definitions and type-safe query builders.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,8 +8,8 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_orm: ^0.1.1
-  aim_postgres: ^0.1.1
+  aim_orm: ^0.2.0
+  aim_postgres: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/aim_postgres/CHANGELOG.md
+++ b/packages/aim_postgres/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 ### Features
 

--- a/packages/aim_postgres/pubspec.yaml
+++ b/packages/aim_postgres/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_postgres
 description: A native PostgreSQL driver for Dart with full wire protocol implementation. Supports SSL/TLS, SCRAM-SHA-256 authentication, and parameterized queries.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_database: ^0.1.1
+  aim_database: ^0.2.0
   crypto: ^3.0.7
 
 

--- a/packages/aim_server/CHANGELOG.md
+++ b/packages/aim_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 - **Breaking:** follows `aim_core`'s rename of `Env` → `Variables` and `envFactory` → `variablesFactory` (re-exported).
 - Internals moved to the new `aim_core` package. `aim_server` re-exports it, so existing imports keep working.

--- a/packages/aim_server/pubspec.yaml
+++ b/packages/aim_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server
 description: Run Aim web applications on the Dart VM with dart:io HttpServer. Re-exports aim_core.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/aim_server_basic_auth/CHANGELOG.md
+++ b/packages/aim_server_basic_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
 - **Breaking:** `BasicAuthEnv` is renamed to `BasicAuthVariables` (deprecated typedef kept for one release). `basicAuth()` now requires `E extends BasicAuthVariables`.
 

--- a/packages/aim_server_basic_auth/pubspec.yaml
+++ b/packages/aim_server_basic_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_basic_auth
 description: Basic authentication middleware for Aim framework. Provides RFC 7617 compliant HTTP Basic Authentication with customizable user verification, realm support, and path exclusion.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,11 +8,11 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
   crypto: ^3.0.7
 
 dev_dependencies:
-  aim_server: ^0.1.1
-  aim_server_testing: ^0.1.1
+  aim_server: ^0.2.0
+  aim_server_testing: ^0.2.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_server_cookie/CHANGELOG.md
+++ b/packages/aim_server_cookie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_server_cookie/pubspec.yaml
+++ b/packages/aim_server_cookie/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_cookie
 description: Cookie support for Aim framework with secure options like HttpOnly, SameSite, and expiration.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,9 +8,9 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
 
 dev_dependencies:
-  aim_server: ^0.1.1
+  aim_server: ^0.2.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_server_cors/CHANGELOG.md
+++ b/packages/aim_server_cors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_server_cors/pubspec.yaml
+++ b/packages/aim_server_cors/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_cors
 description: CORS middleware for the aim_server framework.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/aim_server_form/CHANGELOG.md
+++ b/packages/aim_server_form/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_server_form/pubspec.yaml
+++ b/packages/aim_server_form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_form
 description: Form data parsing for aim_server framework. Supports application/x-www-form-urlencoded format.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,9 +8,9 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
 
 dev_dependencies:
-  aim_server: ^0.1.1
+  aim_server: ^0.2.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_server_jwt/CHANGELOG.md
+++ b/packages/aim_server_jwt/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 - **Breaking:** `JwtEnv` is renamed to `JwtVariables` (deprecated typedef kept for one release). `jwt()` now requires `E extends JwtVariables`.
 

--- a/packages/aim_server_jwt/pubspec.yaml
+++ b/packages/aim_server_jwt/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_jwt
 description: JWT authentication middleware for Aim framework. Provides stateless authentication with HS256 support, standard claims validation, and Bearer token verification.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,11 +8,11 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
   crypto: ^3.0.7
 
 dev_dependencies:
-  aim_server: ^0.1.1
-  aim_server_testing: ^0.1.1
+  aim_server: ^0.2.0
+  aim_server_testing: ^0.2.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_server_logger/CHANGELOG.md
+++ b/packages/aim_server_logger/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_server_logger/pubspec.yaml
+++ b/packages/aim_server_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_logger
 description: HTTP logging middleware for aim_server with request/response details and customizable output formats.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,10 +8,10 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
 
 dev_dependencies:
-  aim_server: ^0.1.1
-  aim_server_testing: ^0.1.1
+  aim_server: ^0.2.0
+  aim_server_testing: ^0.2.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_server_multipart/CHANGELOG.md
+++ b/packages/aim_server_multipart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 - **Breaking:** `UploadedFile.saveTo()` moved to the `UploadedFileIO` extension in `package:aim_server_multipart/aim_server_multipart_io.dart`. Add that import to keep using it.
 - `aim_server_multipart.dart` now exports `MultipartFormData`, `UploadedFile`, `parseMultipart`, and the `MultipartRequest` extension (previously only a placeholder was exported).

--- a/packages/aim_server_multipart/pubspec.yaml
+++ b/packages/aim_server_multipart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_multipart
 description: Multipart form data parsing for aim_server framework. Supports multipart/form-data format.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,10 +8,10 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
   mime: ^2.0.0
 
 dev_dependencies:
-  aim_server: ^0.1.1
+  aim_server: ^0.2.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_server_sse/CHANGELOG.md
+++ b/packages/aim_server_sse/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_server_sse/pubspec.yaml
+++ b/packages/aim_server_sse/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_sse
 description: Server-Sent Events (SSE) support for aim_server with real-time streaming capabilities.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,10 +8,10 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
 
 dev_dependencies:
-  aim_server: ^0.1.1
-  aim_server_testing: ^0.1.1
+  aim_server: ^0.2.0
+  aim_server_testing: ^0.2.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/aim_server_static/CHANGELOG.md
+++ b/packages/aim_server_static/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_server_static/pubspec.yaml
+++ b/packages/aim_server_static/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_static
 description: Static file serving middleware for the Aim framework with security built-in.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_server: ^0.1.1
+  aim_server: ^0.2.0
   mime: ^2.0.0
   path: ^1.9.1
 

--- a/packages/aim_server_testing/CHANGELOG.md
+++ b/packages/aim_server_testing/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
 ## 0.1.1
 
 See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.1)

--- a/packages/aim_server_testing/pubspec.yaml
+++ b/packages/aim_server_testing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aim_server_testing
 description: Testing utilities for the Aim framework. Provides test helpers, matchers, and mock objects for testing Aim applications.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/aim-dart/aim
 resolution: workspace
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
-  aim_core: ^0.1.1
+  aim_core: ^0.2.0
   test: ^1.25.6
 
 dev_dependencies:

--- a/tools/release/bin/bump.dart
+++ b/tools/release/bin/bump.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:release/changelog.dart';
+import 'package:release/pubspec_bump.dart';
 import 'package:release/template_pins.dart';
+import 'package:release/workspace.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
@@ -23,32 +25,32 @@ void main(List<String> args) {
     exit(1);
   }
 
-  final packagesDir = Directory('packages');
-  if (!packagesDir.existsSync()) {
-    stderr.writeln('packages directory not found. Run from repository root.');
-    exit(1);
-  }
+  final memberPaths = _resolveWorkspaceMembers();
 
-  final pubspecFiles = <File>[];
-  for (final entity in packagesDir.listSync()) {
-    if (entity is Directory) {
-      final pubspec = File('${entity.path}/pubspec.yaml');
-      if (pubspec.existsSync()) {
-        pubspecFiles.add(pubspec);
-      }
+  final memberFiles = <File>[];
+  for (final member in memberPaths) {
+    final pubspec = File('$member/pubspec.yaml');
+    if (pubspec.existsSync()) {
+      memberFiles.add(pubspec);
     }
   }
 
-  if (pubspecFiles.isEmpty) {
-    stderr.writeln('No pubspec.yaml files found in packages/');
+  if (memberFiles.isEmpty) {
+    stderr.writeln('No workspace member pubspec.yaml files found.');
     exit(1);
   }
 
   stdout.writeln('Bumping version to $newVersion\n');
 
-  for (final file in pubspecFiles) {
-    _updatePubspec(file, newVersion);
-    _updateChangelog(file.parent, newVersion);
+  var packageCount = 0;
+  for (final file in memberFiles) {
+    if (_isTopLevelPackage(file.parent.path)) {
+      _updatePubspec(file, newVersion);
+      _updateChangelog(file.parent, newVersion);
+      packageCount++;
+    } else {
+      _updateWorkspaceMemberDeps(file, newVersion);
+    }
   }
 
   // Update aim_* pins embedded in the aim_cli scaffold templates
@@ -57,7 +59,7 @@ void main(List<String> args) {
   // Update docs version
   _updateDocsVersion(newVersion);
 
-  stdout.writeln('\nDone! Updated ${pubspecFiles.length} packages to $newVersion');
+  stdout.writeln('\nDone! Updated $packageCount packages to $newVersion');
   stdout.writeln('\nNext steps:');
   stdout.writeln('  1. Review changes: git diff');
   stdout.writeln('  2. Commit: git commit -am "chore: bump version to $newVersion"');
@@ -71,21 +73,86 @@ bool _isValidVersion(String version) {
   return regex.hasMatch(version);
 }
 
+/// Returns the ordered list of workspace member directories to process.
+///
+/// Reads the `workspace:` list from the root `pubspec.yaml`. If the root
+/// pubspec has no `workspace:` list (or doesn't exist), falls back to
+/// scanning `packages/*` directly, matching the tool's original behaviour.
+List<String> _resolveWorkspaceMembers() {
+  final rootPubspec = File('pubspec.yaml');
+  if (rootPubspec.existsSync()) {
+    final members = workspaceMembers(rootPubspec.readAsStringSync());
+    if (members.isNotEmpty) {
+      return members;
+    }
+  }
+
+  final packagesDir = Directory('packages');
+  if (!packagesDir.existsSync()) {
+    stderr.writeln('packages directory not found. Run from repository root.');
+    exit(1);
+  }
+
+  return [
+    for (final entity in packagesDir.listSync())
+      if (entity is Directory) entity.path,
+  ];
+}
+
+/// Whether [memberPath] is a top-level package directory, i.e. exactly one
+/// segment under `packages/` (as opposed to a nested workspace member such
+/// as a golden-test fixture, example, or tool).
+bool _isTopLevelPackage(String memberPath) {
+  final normalized = memberPath.replaceAll(Platform.pathSeparator, '/');
+  if (!normalized.startsWith('packages/')) {
+    return false;
+  }
+  final rest = normalized.substring('packages/'.length);
+  return rest.isNotEmpty && !rest.contains('/');
+}
+
 void _updatePubspec(File file, String newVersion) {
   final content = file.readAsStringSync();
   final yaml = loadYaml(content) as YamlMap;
-  final editor = YamlEditor(content);
 
   final packageName = yaml['name'] as String;
   final oldVersion = yaml['version'] as String?;
 
+  var updated = content;
+
   // Update version
   if (oldVersion != null) {
+    final editor = YamlEditor(updated);
     editor.update(['version'], newVersion);
+    updated = editor.toString();
     stdout.writeln('$packageName: $oldVersion → $newVersion');
   }
 
-  // Update aim_* dependencies
+  _printAimConstraintChanges(yaml, newVersion);
+  updated = bumpAimConstraints(updated, newVersion);
+
+  file.writeAsStringSync(updated);
+}
+
+/// Updates only the `aim_*` dependency/dev_dependency constraints of a
+/// workspace member that is not a top-level package (fixtures, examples,
+/// tools). Does not touch `version:` or the CHANGELOG.
+void _updateWorkspaceMemberDeps(File file, String newVersion) {
+  final content = file.readAsStringSync();
+  final yaml = loadYaml(content) as YamlMap;
+  final packageName = (yaml['name'] as String?) ?? file.parent.path;
+
+  stdout.writeln('$packageName (workspace member): deps only');
+  _printAimConstraintChanges(yaml, newVersion);
+
+  final updated = bumpAimConstraints(content, newVersion);
+  file.writeAsStringSync(updated);
+}
+
+/// Prints the `  └─ <dep>: ^old → ^new` lines for every `aim_*`
+/// dependency/dev_dependency constraint in [yaml] that will be bumped to
+/// [newVersion]. Does not perform the update itself.
+void _printAimConstraintChanges(YamlMap yaml, String newVersion) {
   final dependencies = yaml['dependencies'];
   if (dependencies is YamlMap) {
     for (final dep in dependencies.keys) {
@@ -93,14 +160,12 @@ void _updatePubspec(File file, String newVersion) {
       if (_isAimPackage(depName)) {
         final currentVersion = dependencies[depName];
         if (currentVersion is String) {
-          editor.update(['dependencies', depName], '^$newVersion');
           stdout.writeln('  └─ $depName: $currentVersion → ^$newVersion');
         }
       }
     }
   }
 
-  // Update aim_* dev_dependencies
   final devDependencies = yaml['dev_dependencies'];
   if (devDependencies is YamlMap) {
     for (final dep in devDependencies.keys) {
@@ -108,14 +173,11 @@ void _updatePubspec(File file, String newVersion) {
       if (_isAimPackage(depName)) {
         final currentVersion = devDependencies[depName];
         if (currentVersion is String) {
-          editor.update(['dev_dependencies', depName], '^$newVersion');
           stdout.writeln('  └─ $depName (dev): $currentVersion → ^$newVersion');
         }
       }
     }
   }
-
-  file.writeAsStringSync(editor.toString());
 }
 
 bool _isAimPackage(String packageName) {

--- a/tools/release/bin/bump.dart
+++ b/tools/release/bin/bump.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:release/changelog.dart';
 import 'package:release/template_pins.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
@@ -60,7 +61,9 @@ void main(List<String> args) {
   stdout.writeln('\nNext steps:');
   stdout.writeln('  1. Review changes: git diff');
   stdout.writeln('  2. Commit: git commit -am "chore: bump version to $newVersion"');
-  stdout.writeln('  3. Tag: git tag v$newVersion');
+  stdout.writeln(
+    '  3. Tag: git tag $newVersion  (no "v" prefix: docs deploy and create_release expect 0.2.0-style tags)',
+  );
 }
 
 bool _isValidVersion(String version) {
@@ -121,38 +124,45 @@ bool _isAimPackage(String packageName) {
 
 const _repoUrl = 'https://github.com/aim-dart/aim';
 
+final _unreleasedHeadingPattern = RegExp(
+  r'^\s*##\s*unreleased\s*$',
+  multiLine: true,
+  caseSensitive: false,
+);
+
 void _updateChangelog(Directory packageDir, String newVersion) {
   final changelogFile = File('${packageDir.path}/CHANGELOG.md');
-  final newEntry = '''## $newVersion
+  final packageName = packageDir.path
+      .split(Platform.pathSeparator)
+      .where((segment) => segment.isNotEmpty)
+      .last;
 
-See [Release Notes]($_repoUrl/releases/tag/$newVersion)
-''';
-
-  if (changelogFile.existsSync()) {
-    final content = changelogFile.readAsStringSync();
-
-    // Check if this version already exists
-    if (content.contains('## $newVersion')) {
-      return;
-    }
-
-    // Insert at the beginning, or after # Changelog header if exists
-    final lines = content.split('\n');
-    final headerIndex = lines.indexWhere((line) => line.startsWith('# '));
-
-    if (headerIndex != -1) {
-      lines.insert(headerIndex + 1, '\n$newEntry');
-    } else {
-      // No header, insert at beginning
-      lines.insert(0, '$newEntry\n');
-    }
-    changelogFile.writeAsStringSync(lines.join('\n'));
-  } else {
+  if (!changelogFile.existsSync()) {
     // Create new CHANGELOG.md
     final content = '''# Changelog
 
-$newEntry''';
+## $newVersion
+
+See [Release Notes]($_repoUrl/releases/tag/$newVersion)
+''';
     changelogFile.writeAsStringSync(content);
+    stdout.writeln('$packageName: CHANGELOG + $newVersion');
+    return;
+  }
+
+  final content = changelogFile.readAsStringSync();
+  final hadUnreleased = _unreleasedHeadingPattern.hasMatch(content);
+  final updated = bumpChangelog(content, newVersion, repoUrl: _repoUrl);
+
+  if (updated == content) {
+    return;
+  }
+
+  changelogFile.writeAsStringSync(updated);
+  if (hadUnreleased) {
+    stdout.writeln('$packageName: CHANGELOG Unreleased → $newVersion');
+  } else {
+    stdout.writeln('$packageName: CHANGELOG + $newVersion');
   }
 }
 

--- a/tools/release/lib/changelog.dart
+++ b/tools/release/lib/changelog.dart
@@ -1,0 +1,57 @@
+/// Matches a `## Unreleased` heading line, case-insensitively and
+/// tolerating trailing spaces/tabs (and a trailing `\r` from CRLF content,
+/// which callers strip before matching).
+final RegExp _unreleasedHeading = RegExp(
+  r'^## unreleased[ \t]*$',
+  caseSensitive: false,
+);
+
+/// Returns [content] with the release [version] applied.
+///
+/// - If a `## Unreleased` heading exists, it is renamed to `## [version]`
+///   and its entries are kept.
+/// - Otherwise, if `## [version]` already exists, [content] is returned
+///   unchanged.
+/// - Otherwise a `## [version]` block with
+///   `See [Release Notes](<repoUrl>/releases/tag/<version>)` is inserted
+///   after the first `# ` header, or at the top when there is none.
+String bumpChangelog(String content, String version, {required String repoUrl}) {
+  final lines = content.split('\n');
+
+  final unreleasedIndex = lines.indexWhere(_isUnreleasedHeadingLine);
+  if (unreleasedIndex != -1) {
+    final line = lines[unreleasedIndex];
+    final hadTrailingCr = line.endsWith('\r');
+    lines[unreleasedIndex] = '## $version${hadTrailingCr ? '\r' : ''}';
+    return lines.join('\n');
+  }
+
+  if (content.contains('## $version')) {
+    return content;
+  }
+
+  final headerIndex = lines.indexWhere((line) => line.startsWith('# '));
+
+  // Insert right after the top-level header (or at the top when there is
+  // none), reusing an existing blank line as the separator instead of
+  // adding a second one.
+  var insertionIndex = headerIndex + 1;
+  if (insertionIndex < lines.length && lines[insertionIndex].isEmpty) {
+    insertionIndex++;
+  }
+
+  lines.insertAll(insertionIndex, [
+    '## $version',
+    '',
+    'See [Release Notes]($repoUrl/releases/tag/$version)',
+    '',
+  ]);
+  return lines.join('\n');
+}
+
+bool _isUnreleasedHeadingLine(String line) {
+  final stripped = line.endsWith('\r')
+      ? line.substring(0, line.length - 1)
+      : line;
+  return _unreleasedHeading.hasMatch(stripped);
+}

--- a/tools/release/lib/pubspec_bump.dart
+++ b/tools/release/lib/pubspec_bump.dart
@@ -1,0 +1,44 @@
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+/// Aim packages that should be versioned together.
+const _aimPackagePrefixes = ['aim_'];
+
+const _constraintSections = ['dependencies', 'dev_dependencies'];
+
+/// Rewrites `aim_*` `dependencies`/`dev_dependencies` entries in
+/// [pubspecYaml] whose value is a plain version-constraint string (e.g.
+/// `aim_orm: ^0.1.1`) to `^newVersion`.
+///
+/// Map-valued entries (e.g. `aim_server: {path: ../aim_server}`, as used by
+/// `examples/*`) are left untouched, as is everything else in the document
+/// (including `version:`).
+String bumpAimConstraints(String pubspecYaml, String newVersion) {
+  final yaml = loadYaml(pubspecYaml) as YamlMap;
+  final editor = YamlEditor(pubspecYaml);
+
+  for (final section in _constraintSections) {
+    final deps = yaml[section];
+    if (deps is! YamlMap) {
+      continue;
+    }
+
+    for (final dep in deps.keys) {
+      final depName = dep as String;
+      if (!_isAimPackage(depName)) {
+        continue;
+      }
+
+      final currentVersion = deps[depName];
+      if (currentVersion is String) {
+        editor.update([section, depName], '^$newVersion');
+      }
+    }
+  }
+
+  return editor.toString();
+}
+
+bool _isAimPackage(String packageName) {
+  return _aimPackagePrefixes.any(packageName.startsWith);
+}

--- a/tools/release/lib/workspace.dart
+++ b/tools/release/lib/workspace.dart
@@ -1,0 +1,23 @@
+import 'package:yaml/yaml.dart';
+
+/// Member directories listed under `workspace:` in a root pubspec.yaml, in
+/// order.
+///
+/// Returns an empty list when [rootPubspecYaml] has no `workspace:` list
+/// (or it is empty).
+List<String> workspaceMembers(String rootPubspecYaml) {
+  final yaml = loadYaml(rootPubspecYaml);
+  if (yaml is! YamlMap) {
+    return [];
+  }
+
+  final workspace = yaml['workspace'];
+  if (workspace is! YamlList) {
+    return [];
+  }
+
+  return [
+    for (final entry in workspace)
+      if (entry is String) entry,
+  ];
+}

--- a/tools/release/test/changelog_test.dart
+++ b/tools/release/test/changelog_test.dart
@@ -1,0 +1,154 @@
+import 'package:release/changelog.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('bumpChangelog', () {
+    const repoUrl = 'https://github.com/aim-dart/aim';
+
+    test('folds ## Unreleased into the new version, keeping entries', () {
+      const content = '''# Changelog
+
+## Unreleased
+
+- **Breaking:** first entry.
+- Second entry.
+- Third entry.
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''';
+
+      final result = bumpChangelog(content, '0.2.0', repoUrl: repoUrl);
+
+      expect(
+        result,
+        '''# Changelog
+
+## 0.2.0
+
+- **Breaking:** first entry.
+- Second entry.
+- Third entry.
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''',
+      );
+    });
+
+    test('inserts a new block after the first # header when no Unreleased '
+        'and no existing version heading', () {
+      const content = '''# Changelog
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''';
+
+      final result = bumpChangelog(content, '0.2.0', repoUrl: repoUrl);
+
+      expect(
+        result,
+        '''# Changelog
+
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''',
+      );
+    });
+
+    test('inserts at the top when there is no header at all', () {
+      const content = '''## 0.1.0
+
+Initial release.
+''';
+
+      final result = bumpChangelog(content, '0.2.0', repoUrl: repoUrl);
+
+      expect(
+        result,
+        '''## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
+## 0.1.0
+
+Initial release.
+''',
+      );
+    });
+
+    test('is unchanged when ## <version> already exists and there is no '
+        'Unreleased section', () {
+      const content = '''# Changelog
+
+## 0.2.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.2.0)
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''';
+
+      final result = bumpChangelog(content, '0.2.0', repoUrl: repoUrl);
+
+      expect(result, content);
+    });
+
+    test('is idempotent: applying twice equals applying once', () {
+      const content = '''# Changelog
+
+## Unreleased
+
+- Some entry.
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''';
+
+      final once = bumpChangelog(content, '0.2.0', repoUrl: repoUrl);
+      final twice = bumpChangelog(once, '0.2.0', repoUrl: repoUrl);
+
+      expect(twice, once);
+    });
+
+    test('folds a lowercase "## unreleased " heading with a trailing space',
+        () {
+      const content = '''# Changelog
+
+## unreleased 
+
+- An entry.
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''';
+
+      final result = bumpChangelog(content, '0.2.0', repoUrl: repoUrl);
+
+      expect(
+        result,
+        '''# Changelog
+
+## 0.2.0
+
+- An entry.
+
+## 0.1.0
+
+See [Release Notes](https://github.com/aim-dart/aim/releases/tag/0.1.0)
+''',
+      );
+    });
+  });
+}

--- a/tools/release/test/pubspec_bump_test.dart
+++ b/tools/release/test/pubspec_bump_test.dart
@@ -1,0 +1,103 @@
+import 'package:release/pubspec_bump.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('bumpAimConstraints', () {
+    test('bumps aim_* dependencies that are plain version strings', () {
+      const pubspec = '''
+name: simple_table_fixture
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.0
+
+dependencies:
+  aim_orm: ^0.1.1
+  aim_orm_postgres: ^0.1.1
+  aim_postgres: ^0.1.1
+  aim_database: ^0.1.1
+
+dev_dependencies:
+  aim_orm_codegen: ^0.1.1
+  build_runner: ^2.4.0
+''';
+
+      final result = bumpAimConstraints(pubspec, '0.2.0');
+
+      expect(result, contains('aim_orm: ^0.2.0'));
+      expect(result, contains('aim_orm_postgres: ^0.2.0'));
+      expect(result, contains('aim_postgres: ^0.2.0'));
+      expect(result, contains('aim_database: ^0.2.0'));
+      expect(result, contains('aim_orm_codegen: ^0.2.0'));
+      expect(result, isNot(contains('^0.1.1')));
+    });
+
+    test('leaves non-aim_* dependencies untouched', () {
+      const pubspec = '''
+name: simple_table_fixture
+dependencies:
+  aim_orm: ^0.1.1
+
+dev_dependencies:
+  aim_orm_codegen: ^0.1.1
+  build_runner: ^2.4.0
+''';
+
+      final result = bumpAimConstraints(pubspec, '0.2.0');
+
+      expect(result, contains('build_runner: ^2.4.0'));
+    });
+
+    test('leaves path: map-valued aim_* dependencies untouched', () {
+      const pubspec = '''
+name: basic_sample
+dependencies:
+  aim_server:
+    path: ../../packages/aim_server
+  aim_server_cors:
+    path: ../../packages/aim_server_cors
+
+dev_dependencies:
+  aim_server_testing:
+    path: ../../packages/aim_server_testing
+  lints: ^6.0.0
+''';
+
+      final result = bumpAimConstraints(pubspec, '0.2.0');
+
+      expect(result, contains('path: ../../packages/aim_server'));
+      expect(result, contains('path: ../../packages/aim_server_cors'));
+      expect(result, contains('path: ../../packages/aim_server_testing'));
+      expect(result, isNot(contains('^0.2.0')));
+    });
+
+    test('does not touch version:', () {
+      const pubspec = '''
+name: aim_core
+version: 0.1.1
+dependencies:
+  aim_database: ^0.1.1
+''';
+
+      final result = bumpAimConstraints(pubspec, '0.2.0');
+
+      expect(result, contains('version: 0.1.1'));
+      expect(result, contains('aim_database: ^0.2.0'));
+    });
+
+    test('is idempotent when already at the target version', () {
+      const pubspec = '''
+name: simple_table_fixture
+dependencies:
+  aim_orm: ^0.2.0
+''';
+
+      final result = bumpAimConstraints(pubspec, '0.2.0');
+      final result2 = bumpAimConstraints(result, '0.2.0');
+
+      expect(result2, equals(result));
+      expect(result, contains('aim_orm: ^0.2.0'));
+    });
+  });
+}

--- a/tools/release/test/workspace_test.dart
+++ b/tools/release/test/workspace_test.dart
@@ -1,0 +1,47 @@
+import 'package:release/workspace.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('workspaceMembers', () {
+    test('returns members listed under workspace: in order', () {
+      const pubspec = '''
+name: _
+publish_to: none
+environment:
+  sdk: ^3.13.0
+workspace:
+  - packages/aim_core
+  - packages/aim_server
+  - tools/release
+''';
+
+      final result = workspaceMembers(pubspec);
+
+      expect(result, [
+        'packages/aim_core',
+        'packages/aim_server',
+        'tools/release',
+      ]);
+    });
+
+    test('returns an empty list when there is no workspace: list', () {
+      const pubspec = '''
+name: some_package
+version: 1.0.0
+environment:
+  sdk: ^3.13.0
+''';
+
+      expect(workspaceMembers(pubspec), isEmpty);
+    });
+
+    test('returns an empty list for an empty workspace: list', () {
+      const pubspec = '''
+name: _
+workspace: []
+''';
+
+      expect(workspaceMembers(pubspec), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Version bump to **0.2.0** for all 19 packages, plus the release-tooling fixes needed to do it cleanly. Merging this PR does not publish anything; publishing, tagging and the GitHub Release are separate manual steps (below).

## In this PR

- `dart run release:bump 0.2.0` applied: every `packages/*/pubspec.yaml` at `0.2.0`, all `aim_*` constraints at `^0.2.0` (dependencies, dev_dependencies, golden-test fixtures, `aim create` templates), docs `config.mts` at `v0.2.0`.
- Package CHANGELOGs: the `## Unreleased` sections are folded into `## 0.2.0`; packages without pending entries get the usual "See Release Notes" block.
- Root `CHANGELOG.md`: 0.2.0 release notes (highlights, breaking changes, other changes, package list) — this is what `release:create_release 0.2.0` publishes.
- `tools/release/bin/bump.dart`: folds `## Unreleased` instead of stranding it; walks every `workspace:` member (so fixtures/examples/tools get their `aim_*` constraints bumped, not only `packages/*`); tag hint no longer says `v0.2.0` (docs deploy and `create_release` use bare `0.2.0` tags). New pure helpers with tests (`changelog.dart`, `workspace.dart`, `pubspec_bump.dart`).
- `aim_cli` create test asserts the template pin by pattern instead of a literal version.

## Verification

- `dart analyze --fatal-warnings` → 0 warnings
- All package suites green, including `aim_edge` (wasm + wrangler, 18) and `aim_orm_codegen` golden (5; fixtures regenerate byte-identically)
- `dart run release:publish --dry-run` → all 19 packages "0 warnings", "Dry run completed successfully!"

## Release steps after merge (manual)

```bash
git checkout main && git pull
dart pub login                       # publisher: aim-dart.dev
dart run release:publish             # topological order; aim_core and aim_edge are first-time publishes
git tag 0.2.0 && git push origin 0.2.0    # triggers the docs deploy
dart run release:create_release 0.2.0     # GitHub Release from the root CHANGELOG
```

Then: `aim create smoke --target edge && cd smoke && dart pub get` and the same for `--target server` to confirm the published constraints resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
