### PR TITLE
ci(docs): fix Vercel deploy (run from repo root, explicit install/build)

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -13,15 +14,18 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install Vercel CLI
         run: npm install -g vercel
 
+      # Run from the repository root so the project's Root Directory setting
+      # (docs) is honoured. vercel.json at the root covers the case where the
+      # project root is the repository itself; docs/vercel.json covers the
+      # case where it is docs/.
       - name: Deploy to Vercel
         run: |
-          cd docs
-          vercel pull --yes --token=${{ secrets.VERCEL_TOKEN }}
+          vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
           vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ specs/
 # dart compile wasm output and wrangler state (examples/edge-sample)
 .out/
 .wrangler/
+.vercel/

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npm ci",
   "buildCommand": "npm run docs:build",
   "outputDirectory": ".vitepress/dist"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "cd docs && npm ci",
+  "buildCommand": "cd docs && npm run docs:build",
+  "outputDirectory": "docs/.vitepress/dist"
+}


### PR DESCRIPTION
## Problem

The first run of `Deploy Docs` (tag `0.2.0`) failed:

```
Downloaded project settings to ~/work/aim/aim/docs/.vercel/project.json
WARNING! Build not running on Vercel. System environment variables will not be available.
sh: 1: vitepress: not found
Error: Command "vitepress build docs" exited with 127
```

The workflow ran `vercel pull/build/deploy` inside `docs/`. When the Vercel project's Root Directory is `docs`, the CLI treats the current directory as the repository root and resolves the project to `docs/docs`: no `package.json` there, so no install ran, and the VitePress preset's default `vitepress build docs` was used instead of `docs/vercel.json`'s `npm run docs:build`.

## Fix

- Run the Vercel CLI from the repository root so the Root Directory setting is honoured.
- Declare `installCommand` / `buildCommand` / `outputDirectory` explicitly in both `vercel.json` (root, used if the project root is the repo) and `docs/vercel.json` (used if the project root is `docs/`), so the deploy no longer depends on dashboard defaults.
- `vercel pull --environment=production` for a `--prod` build.
- `workflow_dispatch` trigger so the deploy can be re-run without re-tagging.
- Node 22 for the runner; `.vercel/` ignored.

`cd docs && npm ci && npm run docs:build` verified locally (build completes, `.vitepress/dist` produced).

## After merge

Re-run the deploy for the already-published 0.2.0 docs: Actions → Deploy Docs → Run workflow (or `gh workflow run "Deploy Docs" --ref main`). If it still fails, the dashboard's Root Directory / framework settings need checking; the log will now show which `vercel.json` was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
