### PR TITLE
ci(docs): enable cleanUrls on Vercel

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "npm ci",
   "buildCommand": "npm run docs:build",
-  "outputDirectory": ".vitepress/dist"
+  "outputDirectory": ".vitepress/dist",
+  "cleanUrls": true
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "cd docs && npm ci",
   "buildCommand": "cd docs && npm run docs:build",
-  "outputDirectory": "docs/.vitepress/dist"
+  "outputDirectory": "docs/.vitepress/dist",
+  "cleanUrls": true
 }


### PR DESCRIPTION
## Problem

After #88 the deploy succeeds, but direct requests to sub-pages 404 (`/server/guides/migration` → 404, `/server/guides/migration.html` → 200). VitePress builds with `cleanUrls: true`, and the VitePress framework preset on Vercel used to add the matching `/path` → `/path.html` rewrite. The explicit `vercel.json` from #88 replaced the preset, so the rewrite was lost.

## Fix

`"cleanUrls": true` in both `vercel.json` (repo root) and `docs/vercel.json`.

## After merge

Re-run **Deploy Docs** (workflow_dispatch) and check `curl -I https://aim-dart.dev/server/guides/migration` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)